### PR TITLE
Replace Android app with Flask web expense tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # MoneyExchange
+
+A web-based travel expense tracker built with Flask and jQuery. Select a destination country, set your total budget in Korean Won (KRW), and log expenses in the local currency while the app automatically converts them to KRW.
+
+## Features
+- Choose from a list of countries; the app automatically determines the local currency.
+- Enter a total travel budget in KRW and view the remaining balance.
+- Add expenses in the local currency with an optional note.
+- Expenses are converted to KRW using [exchangerate.host](https://exchangerate.host) and deducted from your budget.
+- View a history table showing the local amount, converted KRW value, note, and remaining budget.
+
+## Setup
+
+### Prerequisites
+- Python 3.8 or later
+
+### Install dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### Run the app
+```bash
+python app.py
+```
+Open `http://localhost:5000` in a browser on Windows or macOS.
+
+## Usage
+1. Choose a destination country and enter your total budget in KRW.
+2. Click **Start Trip** to begin tracking expenses.
+3. Add each expense in the local currency and provide a note if desired.
+4. The table updates with the converted amount and remaining budget after each entry.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,86 @@
+from flask import Flask, render_template, request, jsonify
+from babel.numbers import get_territory_currency
+import pycountry
+import requests
+
+app = Flask(__name__)
+
+# In-memory state for demo purposes
+state = {
+    "country": None,
+    "currency": None,
+    "budget": 0.0,
+    "remaining": 0.0,
+    "expenses": []
+}
+
+
+def get_countries():
+    countries = []
+    for country in pycountry.countries:
+        try:
+            currency = get_territory_currency(country.alpha_2)
+            countries.append({
+                "code": country.alpha_2,
+                "name": country.name,
+                "currency": currency
+            })
+        except Exception:
+            # Some territories may not have a currency
+            continue
+    countries.sort(key=lambda c: c["name"])
+    return countries
+
+
+@app.route("/")
+def index():
+    return render_template("index.html", countries=get_countries(), state=state)
+
+
+@app.route("/set_budget", methods=["POST"])
+def set_budget():
+    data = request.get_json()
+    country_code = data.get("country")
+    budget = float(data.get("budget", 0))
+    currency = get_territory_currency(country_code)
+    state.update({
+        "country": country_code,
+        "currency": currency,
+        "budget": budget,
+        "remaining": budget,
+        "expenses": []
+    })
+    return jsonify({"currency": currency, "remaining": state["remaining"]})
+
+
+@app.route("/add_expense", methods=["POST"])
+def add_expense():
+    if not state.get("currency"):
+        return jsonify({"error": "Budget not set"}), 400
+    data = request.get_json()
+    amount_local = float(data.get("amount", 0))
+    note = data.get("note", "")
+
+    # Call exchange rate API
+    url = (
+        f"https://api.exchangerate.host/convert?from={state['currency']}"
+        f"&to=KRW&amount={amount_local}"
+    )
+    resp = requests.get(url, timeout=10)
+    result = resp.json().get("result")
+    krw_amount = float(result) if result else 0
+
+    state["remaining"] -= krw_amount
+    expense = {
+        "local": amount_local,
+        "currency": state["currency"],
+        "krw": krw_amount,
+        "note": note,
+        "remaining": state["remaining"]
+    }
+    state["expenses"].append(expense)
+    return jsonify(expense)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+requests
+pycountry
+Babel

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,18 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+label {
+    margin-right: 10px;
+}
+
+#history {
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+#history th, #history td {
+    border: 1px solid #ccc;
+    padding: 8px 12px;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,51 @@
+$(function() {
+    $('#start-btn').on('click', function() {
+        const country = $('#country').val();
+        const budget = parseFloat($('#budget').val());
+        if (!budget || budget <= 0) {
+            alert('Enter a valid budget');
+            return;
+        }
+        $.ajax({
+            url: '/set_budget',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({country: country, budget: budget}),
+            success: function(res) {
+                $('#currency-code').text(res.currency);
+                $('#remaining').text(res.remaining.toFixed(2));
+                $('#setup').hide();
+                $('#tracker').show();
+            }
+        });
+    });
+
+    $('#add-expense').on('click', function() {
+        const amount = parseFloat($('#amount').val());
+        const note = $('#note').val();
+        if (!amount || amount <= 0) {
+            alert('Enter a valid amount');
+            return;
+        }
+        $.ajax({
+            url: '/add_expense',
+            method: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({amount: amount, note: note}),
+            success: function(res) {
+                const row = $('<tr>');
+                row.append($('<td>').text(amount.toFixed(2) + ' ' + res.currency));
+                row.append($('<td>').text(res.krw.toFixed(2)));
+                row.append($('<td>').text(res.note));
+                row.append($('<td>').text(res.remaining.toFixed(2)));
+                $('#history tbody').append(row);
+                $('#remaining').text(res.remaining.toFixed(2));
+                $('#amount').val('');
+                $('#note').val('');
+            },
+            error: function(err) {
+                alert(err.responseJSON.error);
+            }
+        });
+    });
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Travel Expense Tracker</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="/static/js/app.js"></script>
+</head>
+<body>
+<h1>Travel Expense Tracker</h1>
+<div id="setup">
+    <label for="country">Destination Country:</label>
+    <select id="country">
+        {% for c in countries %}
+        <option value="{{ c.code }}" data-currency="{{ c.currency }}">{{ c.name }}</option>
+        {% endfor %}
+    </select>
+    <label for="budget">Total Budget (KRW):</label>
+    <input type="number" id="budget" min="0">
+    <button id="start-btn">Start Trip</button>
+</div>
+
+<div id="tracker" style="display:none;">
+    <p>Currency: <span id="currency-code"></span></p>
+    <p>Remaining Budget: <span id="remaining"></span> KRW</p>
+    <h2>Add Expense</h2>
+    <label for="amount">Amount:</label>
+    <input type="number" id="amount" min="0" step="0.01">
+    <label for="note">Note:</label>
+    <input type="text" id="note">
+    <button id="add-expense">Add</button>
+
+    <h2>Expenses</h2>
+    <table id="history">
+        <thead>
+        <tr>
+            <th>Local Amount</th>
+            <th>KRW</th>
+            <th>Note</th>
+            <th>Remaining KRW</th>
+        </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove Android project files
- add Flask backend and jQuery frontend to track travel expenses with automatic KRW conversion
- document setup and usage for the web application

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2c0b1a0988325824f480bfa9ed79a